### PR TITLE
Remove use of deprecated standard

### DIFF
--- a/resumable.js
+++ b/resumable.js
@@ -300,7 +300,7 @@ var Resumable = function(opts){
       formData.append('resumableIdentifier', $.fileObj.uniqueIdentifier);
       formData.append('resumableFilename', $.fileObj.fileName);
       // Append the relevant chunk and send it
-      var func = ($.fileObj.file.mozSlice ? 'mozSlice' : ($.fileObj.file.webkitSlice ? 'webkitSlice' : 'slice'));
+      var func = ($.fileObj.file.slice ? 'slice' : ($.fileObj.file.mozSlice ? 'mozSlice' : ($.fileObj.file.webkitSlice ? 'webkitSlice' : 'slice')));
       formData.append($.resumableObj.opts.fileParameterName, $.fileObj.file[func]($.startByte,$.endByte));
       $.xhr.open("POST", $.resumableObj.opts.target);
       //$.xhr.open("POST", '/sandbox');


### PR DESCRIPTION
Hi,

I have made a very minor change so that 'slice' for the files is used instead of the webkit/moz versions (if it exists), this ensures future compatibility and removes a warning from the latest Chrome versions.
