### PR TITLE
support for single file uploading

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,8 +82,8 @@ Available configuration options are:
 * `query` Extra parameters to include in the multipart POST with data (Default: `{}`)
 * `prioritizeFirstAndLastChunk` Prioritize first and last chunks of all files. This can be handy if you can determine if a file is valid for your service from only the first or last chunk. For example, photo or video meta data is usually located in the first part of a file, making it easy to test support from only the first chunk. (Default: `false`)
 * `testChunks` Make a GET request to the server for each chunks to see if it already exists. If implemented on the server-side, this will allow for upload resumes even after a browser crash or even a computer restart. (Default: `true`)
-* `allowMultiplefiles` Indicates whether multiple files can be selected by the user at the same time. Valid values are `true` and `false`. (Default: `true`)
-* `showSelectSingleFileCallback` A function which displays the *please upload one file at a time* message. (Default: displays an alert box with the message *Please upload one file at a time.*)
+* `maxFiles` Indicates how many files can be uploaded in a single session. Valid values are any positive integer and `undefined` for no limit. (Default: `undefined`)
+* `maxFilesErrorCallback` A function which displays the *please upload n file(s) at a time* message. (Default: displays an alert box with the message *Please n one file(s) at a time.*)
 
 #### Properties
 

--- a/resumable.js
+++ b/resumable.js
@@ -39,9 +39,9 @@ var Resumable = function(opts){
     prioritizeFirstAndLastChunk:false,
     target:'/',
     testChunks:true,
-    allowMultiplefiles:true,
-    showSelectSingleFileCallback:function () {
-      alert('Please upload one file at a time.');
+    maxFiles:undefined,
+    maxFilesErrorCallback:function () {
+      alert('Please upload ' + $.opts.maxFiles + ' file' + ($.opts.maxFiles === 1 ? '' : 's') + ' at a time.');
     }
   };
 
@@ -97,9 +97,9 @@ var Resumable = function(opts){
 
   // INTERNAL METHODS (both handy and responsible for the heavy load)
   var appendFilesFromFileList = function(fileList){
-    // check for multiple files in a
-    if (!$.opts.allowMultiplefiles&&fileList.length != 1) {
-      $.opts.showSelectSingleFileCallback();
+    // check for uploading too many files
+    if (typeof($.opts.maxFiles)!=='undefined'&&opts.maxFiles<(fileList.length+$.files.length)) {
+      $.opts.maxFilesErrorCallback();
       return false;
     }
 
@@ -433,7 +433,7 @@ var Resumable = function(opts){
         } else {
             input = document.createElement('input');
             input.setAttribute('type', 'file');
-            if ($.opts.allowMultiplefiles)
+            if (typeof($.opts.maxFiles)==='undefined'||$.opts.maxFiles!=1)
               input.setAttribute('multiple', 'multiple');
 
             // Place <input multiple /> with the dom node an position the input to fill the entire space


### PR DESCRIPTION
Hi Steffen,

I have implemented the single file upload mode for resumable.js and updated the documentation as accordingly. The change should be backward compatible.

Unfortunately it was not possible to limit the number of files uploaded at the UI level since the `type="upload"` only allows multiple or not. See http://www.w3.org/TR/html-markup/input.file.html#input.file.attrs.multiple. We could however do this check in the `appendFilesFromFileList` method.

I was unsure on how to handle selecting a single file multiple times, so it is still possible to repeatedly select a single file. Could you advice on how to implement this check?

Other feedback is welcome as well.

Regards,
Bert
