### PR TITLE
Allow the query option to be an object or a function that returns an object.

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ Available configuration options are:
 * `chunkSize` The size in bytes of each uploaded chunk of data (Default: `1*1024*1024`)
 * `simultaneousUploads` Number of simultaneous uploads (Default: `3`)
 * `fileParameterName` The name of the multipart POST parameter to use for the file chunk  (Default: `file`)
-* `query` Extra parameters to include in the multipart POST with data (Default: `{}`)
+* `query` Extra parameters to include in the multipart POST with data. This can be an object or a function. If a function, it will be passed a ResumableFile object (Default: `{}`)
 * `headers` Extra headers to include in the multipart POST with data (Default: `{}`)
 * `prioritizeFirstAndLastChunk` Prioritize first and last chunks of all files. This can be handy if you can determine if a file is valid for your service from only the first or last chunk. For example, photo or video meta data is usually located in the first part of a file, making it easy to test support from only the first chunk. (Default: `false`)
 * `testChunks` Make a GET request to the server for each chunks to see if it already exists. If implemented on the server-side, this will allow for upload resumes even after a browser crash or even a computer restart. (Default: `true`)

--- a/resumable.js
+++ b/resumable.js
@@ -255,7 +255,8 @@ var Resumable = function(opts){
       // Add data from the query options
       var url = ""
       var params = [];
-      $h.each($.resumableObj.opts.query, function(k,v){
+      var query = (typeof $.resumableObj.opts.query == "function") ? $.resumableObj.opts.query($.fileObj) : $.resumableObj.opts.query;
+      $h.each(query, function(k,v){
           params.push([encodeURIComponent(k), encodeURIComponent(v)].join('='));
         });
       // Add extra data to identify chunk
@@ -312,7 +313,8 @@ var Resumable = function(opts){
 
       // Add data from the query options
       var formData = new FormData();
-      $h.each($.resumableObj.opts.query, function(k,v){
+      var query = (typeof $.resumableObj.opts.query == "function") ? $.resumableObj.opts.query($.fileObj) : $.resumableObj.opts.query;
+      $h.each(query, function(k,v){
           formData.append(k,v);
         });
       // Add extra data to identify chunk


### PR DESCRIPTION
The query option can be either an object or a function that returns an object. If query is a function, when the query string is being built, the function is called and is passed the ResumableFile object. In this way you can customize the query parameters per file that is uploaded, to for instance, add custom metadata per each file.
