### PR TITLE
Transmit the real chunk size instead of the theoretically configured one...

### DIFF
--- a/resumable.js
+++ b/resumable.js
@@ -261,7 +261,7 @@ var Resumable = function(opts){
         });
       // Add extra data to identify chunk
       params.push(['resumableChunkNumber', encodeURIComponent($.offset+1)].join('='));
-      params.push(['resumableChunkSize', encodeURIComponent($.resumableObj.opts.chunkSize)].join('='));
+      params.push(['resumableChunkSize', encodeURIComponent($.endByte - $.startByte)].join('='));
       params.push(['resumableTotalSize', encodeURIComponent($.fileObjSize)].join('='));
       params.push(['resumableIdentifier', encodeURIComponent($.fileObj.uniqueIdentifier)].join('='));
       params.push(['resumableFilename', encodeURIComponent($.fileObj.fileName)].join('='));
@@ -319,7 +319,7 @@ var Resumable = function(opts){
         });
       // Add extra data to identify chunk
       formData.append('resumableChunkNumber', $.offset+1);
-      formData.append('resumableChunkSize', $.resumableObj.opts.chunkSize);
+      formData.append('resumableChunkSize', $.endByte - $.startByte);
       formData.append('resumableTotalSize', $.fileObjSize);
       formData.append('resumableIdentifier', $.fileObj.uniqueIdentifier);
       formData.append('resumableFilename', $.fileObj.fileName);


### PR DESCRIPTION
I am unsure how you guys use this value so please advice if I am wrong.

In practice I do not see any reason for the server to use
the configured chunk size as it should be hardened enough to
work with any chunk size provided by the client.

On the other hand the real chunk size can be used to check
if the file transfer was successful or not. Especially
for the last chunk that is bigger most of the time, than the configured size,
we would be unable to detect if the last chunk was successfully transmitted in
case of a browser reload.
