### PR TITLE
Add Component package manager support

### DIFF
--- a/component.json
+++ b/component.json
@@ -1,0 +1,7 @@
+{
+    "name": "resumable.js",
+    "repo": "23/resumable.js",
+    "version": "1.0.0",
+    "main": "resumable.js",
+    "scripts": ["resumable.js"]
+}

--- a/resumable.js
+++ b/resumable.js
@@ -715,3 +715,6 @@ var Resumable = function(opts){
 
   return(this);
 }
+
+// Node.js-style export for Node and Component
+module.exports = Resumable;


### PR DESCRIPTION
Adds support for the [Component](https://github.com/component/component) package manager. Since Component uses the same module system as Node.js, you can also use Resumable in Node.js now!

As Component uses Github as its central repository it is published and installable by default without anyone having to do anything. The only thing needed is the included `component.json` file and module system support.

To support Component's versioning scheme(which isn't mandatory, but very nice and appreciated) you could either pull the tags from my branch or create a tag called: `1.0.0`
