### PR TITLE
Fixed issue with single-file uploaders where one is unable to change what file is first added 

### DIFF
--- a/resumable.js
+++ b/resumable.js
@@ -182,8 +182,13 @@ var Resumable = function(opts){
     var errorCount = 0;
     var o = $.getOpt(['maxFiles', 'minFileSize', 'maxFileSize', 'maxFilesErrorCallback', 'minFileSizeErrorCallback', 'maxFileSizeErrorCallback', 'fileType', 'fileTypeErrorCallback']);
     if (typeof(o.maxFiles)!=='undefined' && o.maxFiles<(fileList.length+$.files.length)) {
-      o.maxFilesErrorCallback(fileList, errorCount++);
-      return false;
+      // if single-file upload, file is already added, and trying to add 1 new file, simply replace the already-added file 
+      if (o.maxFiles===1 && $.files.length===1 && fileList.length===1) {
+        $.removeFile($.files[0]);
+      } else {
+        o.maxFilesErrorCallback(fileList, errorCount++);
+        return false;
+      }
     }
     var files = [];
     $h.each(fileList, function(file){


### PR DESCRIPTION
Problem:
I noticed some buggy behavior when using resumable.js with a single-file uploader (setting MaxFiles=1 and calling addBrowse on an input element with no 'multiple' attribute):
- If you add a file to the input,  and then click and pick a file again (can even be the same file), resumable.js issues the alert "Please upload 1 file at a time." and doesn't change the selected file.
- This is because resumable.js thinks you are trying to add a second file instead of realizing that you are selecting a new file to replace the one you picked the first time.
- Resumable.js should instead imitate the native behavior of the HTML input[type='file'] element (when there is no 'multiple' attribute) and replace the currently selected file with the newly selected file.

Solution:
- In appendFilesFromFileList(), before throwing an error about adding too many files, check if maxFiles is set to 1, you have one file already added, and you are trying to add one new file. If so, replace the file already added with the new file by removing the existing file from $.files and allowing the new file to be added as normal.
