### PR TITLE
Added pause() method for ResumableFile

### DIFF
--- a/resumable.js
+++ b/resumable.js
@@ -247,6 +247,7 @@
       $.size = file.size;
       $.relativePath = file.webkitRelativePath || $.fileName;
       $.uniqueIdentifier = $h.generateUniqueIdentifier(file);
+      $._pause = false;
       var _error = false;
 
       // Callback when something happens within the chunk
@@ -352,6 +353,16 @@
           }
         });
         return(!outstanding);
+      };
+      $.pause = function(pause){
+          if(typeof(pause)==='undefined'){
+              $._pause = ($._pause ? false : true);
+          }else{
+              $._pause = pause;
+          }
+      };
+      $.isPaused = function() {
+        return $._pause;
       };
 
 
@@ -616,13 +627,15 @@
 
       // Now, simply look for the next, best thing to upload
       $h.each($.files, function(file){
-        $h.each(file.chunks, function(chunk){
-          if(chunk.status()=='pending' && chunk.preprocessState === 0) {
-            chunk.send();
-            found = true;
-            return(false);
-          }
-        });
+        if(file.isPaused()===false){
+         $h.each(file.chunks, function(chunk){
+           if(chunk.status()=='pending' && chunk.preprocessState === 0) {
+             chunk.send();
+             found = true;
+             return(false);
+           }
+          });
+        }
         if(found) return(false);
       });
       if(found) return(true);


### PR DESCRIPTION
Last time I was trying to compute MD5 checksum with SparkMD5, as I mentioned here (https://github.com/23/resumable.js/issues/135#issuecomment-31875165) on "fileAdded". It worked for one file, and faild for few.
I needed a way to stop file from being uploaded after added to queue, until script finishes checksum computation...
So I added .pause() method. It doesn't remove file from queue, just makes it invisible for `$.uploadNextChunk()` method.
