### PR TITLE
Added reference to container in ResumableFile & improved browsers compatability

### DIFF
--- a/resumable.js
+++ b/resumable.js
@@ -230,7 +230,7 @@
           window.setTimeout(function(){
             $.files.push(f);
             files.push(f);
-			f.container = event.srcElement;
+            f.container = event.srcElement;
             $.fire('fileAdded', f, event)
           },0);
         })()};
@@ -253,7 +253,7 @@
       $.relativePath = file.webkitRelativePath || $.fileName;
       $.uniqueIdentifier = $h.generateUniqueIdentifier(file);
       $._pause = false;
-	  $.container = '';
+      $.container = '';
       var _error = false;
 
       // Callback when something happens within the chunk
@@ -683,11 +683,11 @@
           input.setAttribute('type', 'file');
           input.style.display = 'none';
           domNode.addEventListener('click', function(){
-			input.style.opacity = 0;
-			input.style.display='block';
-			input.focus();
+            input.style.opacity = 0;
+            input.style.display='block';
+            input.focus();
             input.click();
-			input.style.display='none';
+            input.style.display='none';
           }, false);
           domNode.appendChild(input);
         }


### PR DESCRIPTION
I'd like to suggest some improvements:
- If multiple files are uploaded, it is important to show uploading status and progress in div, which is linked to container where uploaded file was selected. So, I suggest to add a property 'container' to the ResumableFile object.
- File dialog won't open on some versions of Opera and Firefox and other browsers because of they don't allow triggering "click" on hidden elements. I suggest to trigger click event with additional actions: set opacity to 0, show, focus, click, and then hide.
