### PR TITLE
Update on assignBrowseMethod

### DIFF
--- a/resumable.js
+++ b/resumable.js
@@ -687,12 +687,15 @@
           input = document.createElement('input');
           input.setAttribute('type', 'file');
           input.style.display = 'none';
-          domNode.addEventListener('click', function(){
+          domNode.addEventListener('click', function(e){
             input.style.opacity = 0;
             input.style.display='block';
             input.focus();
             input.click();
             input.style.display='none';
+            if (domNode.tagName==='A') {
+              e.prevenyDefault();
+            }
           }, false);
           domNode.appendChild(input);
         }


### PR DESCRIPTION
When using A with href='' or href='#', will often lead developers astray, since the demo, as I recall does not use href in the a tags. The following changes adds a check for A tags and preventDefaults the click. I have tested this in Firefox and seems to work fine.
