### PR TITLE
Update Node.js sample for modern versions of Node and Express.

### DIFF
--- a/samples/Node.js/README.md
+++ b/samples/Node.js/README.md
@@ -1,11 +1,11 @@
 # Sample code for Node.js
 
-This sample is written for [Node.js 0.6+](http://nodejs.org/) and requires [Express](http://expressjs.com/) to make the sample code cleaner.
+This sample is written for [Node.js 0.10+](http://nodejs.org/) and requires [Express 4+](http://expressjs.com/) to make the sample code cleaner.
 
 To install and run:
 
     cd samples/Node.js
-    npm install express
+    npm install
     node app.js
 
 Then browse to [localhost:3000](http://localhost:3000).

--- a/samples/Node.js/app.js
+++ b/samples/Node.js/app.js
@@ -1,11 +1,12 @@
 var express = require('express');
 var resumable = require('./resumable-node.js')('/tmp/resumable.js/');
 var app = express();
+var multipart = require('connect-multiparty');
 
 // Host most stuff in the public folder
 app.use(express.static(__dirname + '/public'));
 
-app.use(express.bodyParser());
+app.use(multipart());
 
 // Handle uploads through Resumable.js
 app.post('/upload', function(req, res){
@@ -37,7 +38,7 @@ app.post('/upload', function(req, res){
 app.get('/upload', function(req, res){
     resumable.get(req, function(status, filename, original_filename, identifier){
         console.log('GET', status);
-        res.send(status, (status == 'found' ? 200 : 404));
+        res.send((status == 'found' ? 200 : 404), status);
       });
   });
 

--- a/samples/Node.js/package.json
+++ b/samples/Node.js/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "resumable.js",
+  "version": "0.0.1",
+  "scripts": {
+    "start": "node app.js"
+  },
+  "dependencies": {
+    "express": "~4.6.1",
+    "connect-multiparty": "~1.1.0"
+  }
+}

--- a/samples/Node.js/resumable-node.js
+++ b/samples/Node.js/resumable-node.js
@@ -71,7 +71,7 @@ module.exports = resumable = function(temporaryFolder){
 
     if(validateRequest(chunkNumber, chunkSize, totalSize, identifier, filename)=='valid') {
       var chunkFilename = getChunkFilename(chunkNumber, identifier);
-      path.exists(chunkFilename, function(exists){
+      fs.exists(chunkFilename, function(exists){
           if(exists){
             callback('found', chunkFilename, filename, identifier);
           } else {
@@ -115,7 +115,7 @@ module.exports = resumable = function(temporaryFolder){
         var currentTestChunk = 1;
         var numberOfChunks = Math.max(Math.floor(totalSize/(chunkSize*1.0)), 1);
         var testChunkExists = function(){
-              path.exists(getChunkFilename(currentTestChunk, identifier), function(exists){
+              fs.exists(getChunkFilename(currentTestChunk, identifier), function(exists){
                 if(exists){
                   currentTestChunk++;
                   if(currentTestChunk>numberOfChunks) {
@@ -153,7 +153,7 @@ module.exports = resumable = function(temporaryFolder){
       var pipeChunk = function(number) {
 
           var chunkFilename = getChunkFilename(number, identifier);
-          path.exists(chunkFilename, function(exists) {
+          fs.exists(chunkFilename, function(exists) {
 
               if (exists) {
                   // If the chunk with the current number exists,
@@ -188,7 +188,7 @@ module.exports = resumable = function(temporaryFolder){
           var chunkFilename = getChunkFilename(number, identifier);
 
           //console.log('removing pipeChunkRm ', number, 'chunkFilename', chunkFilename);
-          path.exists(chunkFilename, function(exists) {
+          fs.exists(chunkFilename, function(exists) {
               if (exists) {
 
                   console.log('exist removing ', chunkFilename);


### PR DESCRIPTION
I updated the Node.js sample to work with the newer, stable versions of node and express.

I fixed the errors and deprecation warnings so that the sample will work out of the box for new users. There were errors for express (a multipart `bodyParser` is no longer bundled), and a few node deprecations as of 0.7 (`path.exists` is now `fs.exists`, and the `send` api changed).

I added a package.json for the dependencies so that users can simply run `npm install` to get the required dependencies (express & connect-multiparty). The `npm start` command can also be used to run the server, as an alternative to `node app.js`
