### PR TITLE
Add: 204-Error to permanentErrors-Array

### DIFF
--- a/resumable.js
+++ b/resumable.js
@@ -50,7 +50,7 @@
       generateUniqueIdentifier:null,
       maxChunkRetries:undefined,
       chunkRetryInterval:undefined,
-      permanentErrors:[404, 415, 500, 501],
+      permanentErrors:[204, 404, 415, 500, 501],
       maxFiles:undefined,
       withCredentials:false,
       xhrTimeout:0,


### PR DESCRIPTION
When uploading there is a HTTP-404 logged to the console every checked chunk, so there is so much logging taking place it is hard to see real errors on the console.
Adding a HTTP-204 would give server-implementations a chance to return this statuscode for signaling the chunk is not available yet (204 - no content). The benefit would be you can find real errors on the console again.