### PR TITLE
Don't stall when a request times out.

### DIFF
--- a/resumable.js
+++ b/resumable.js
@@ -433,6 +433,7 @@
         };
         $.xhr.addEventListener('load', testHandler, false);
         $.xhr.addEventListener('error', testHandler, false);
+        $.xhr.addEventListener('timeout', testHandler, false);
 
         // Add data from the query options
         var params = [];
@@ -518,6 +519,7 @@
         };
         $.xhr.addEventListener('load', doneHandler, false);
         $.xhr.addEventListener('error', doneHandler, false);
+        $.xhr.addEventListener('timeout', doneHandler, false);
 
         // Set up the basic query data from Resumable
         var query = {


### PR DESCRIPTION
Resumable allows setting a timeout on AJAX requests but doesn't handle the ontimeout event when it gets thrown. This causes the uploader to hang whenever a timeout occurs. This change will handle timeout events the same way as a load or error event is handle in the test and send methods of a chunk.
