### PR TITLE
Parse drag-dropped folders and subfolders in Chrome

### DIFF
--- a/resumable.js
+++ b/resumable.js
@@ -251,11 +251,12 @@
           });
         }
         else if (entry.isDirectory) {
+          var directory=entry;
           reader = entry.createReader();
 
           reader.readEntries(function(entries) {
             //process each thing in this directory recursively
-            loadFiles(entries, event, queue, entry.fullPath);
+            loadFiles(entries, event, queue, directory.fullPath);
             //this was a directory rather than a file so decrement the expected file count
             queue.total -= 1;
           }, function(err) {
@@ -266,7 +267,8 @@
     };
 
     var enqueueFileAddition = function(file, queue, path) {
-      file.relativePath = path + '/' + file.name;
+      //store the path to this file if it came in as part of a folder
+      if (path) file.relativePath = path + '/' + file.name;
       queue.files.push(file);
 
       // If all the files we expect have shown up, then flush the queue.


### PR DESCRIPTION
This change allows resumable to parse through folders that are dragged and dropped into the drop zone if the browser supports it (just Chrome for now).  It still handles them in pretty much the usual fashion for other browsers.  

In the interest of full disclosure, the general algorithm for this was found in a blog post at http://code.flickr.net/2012/12/10/drag-n-drop/ 

In addition to simply parsing the directories, I also add a property of .relativePath to files found inside a folder and use that to set the resumableFile.relativePath if file.webkitRelativePath is nothing.