### PR TITLE
Respect HTTP 401 status - unauthorized.

### DIFF
--- a/resumable.js
+++ b/resumable.js
@@ -50,7 +50,7 @@
       generateUniqueIdentifier:null,
       maxChunkRetries:undefined,
       chunkRetryInterval:undefined,
-      permanentErrors:[400, 404, 415, 500, 501],
+      permanentErrors:[400, 401, 404, 415, 500, 501],
       maxFiles:undefined,
       withCredentials:false,
       xhrTimeout:0,
@@ -96,7 +96,7 @@
         else { return $opt.defaults[o]; }
       }
     };
-    
+
     // EVENTS
     // catchAll(event, ...)
     // fileSuccess(file), fileProgress(file), fileAdded(file, event), fileRetry(file), fileError(file, message),
@@ -118,8 +118,8 @@
       if(event=='fileerror') $.fire('error', args[2], args[1]);
       if(event=='fileprogress') $.fire('progress');
     };
-    
-    
+
+
     // INTERNAL HELPER METHODS (handy, but ultimately not part of uploading)
     var $h = {
       stopEvent: function(e){
@@ -203,7 +203,7 @@
     /**
      * @summary This function loops over the files passed in from a drag and drop operation and gets them ready for appendFilesFromFileList
      *            It attempts to use FileSystem API calls to extract files and subfolders if the dropped items include folders
-     *            That capability is only currently available in Chrome, but if it isn't available it will just pass the items along to 
+     *            That capability is only currently available in Chrome, but if it isn't available it will just pass the items along to
      *            appendFilesFromFileList (via enqueueFileAddition to help with asynchronous processing.)
      * @param files {Array} - the File or Entry objects to be processed depending on your browser support
      * @param event {Object} - the drop event object
@@ -301,7 +301,7 @@
      */
     var updateQueueTotal = function(addition, queue){
       queue.total += addition;
-      
+
       // If all the files we expect have shown up, then flush the queue.
       if (queue.files.length === queue.total) {
         appendFilesFromFileList(queue.files, queue.event);
@@ -330,7 +330,7 @@
       var errorCount = 0;
       var o = $.getOpt(['maxFiles', 'minFileSize', 'maxFileSize', 'maxFilesErrorCallback', 'minFileSizeErrorCallback', 'maxFileSizeErrorCallback', 'fileType', 'fileTypeErrorCallback']);
       if (typeof(o.maxFiles)!=='undefined' && o.maxFiles<(fileList.length+$.files.length)) {
-        // if single-file upload, file is already added, and trying to add 1 new file, simply replace the already-added file 
+        // if single-file upload, file is already added, and trying to add 1 new file, simply replace the already-added file
         if (o.maxFiles===1 && $.files.length===1 && fileList.length===1) {
           $.removeFile($.files[0]);
         } else {
@@ -342,7 +342,7 @@
       $h.each(fileList, function(file){
         var fileName = file.name.split('.');
         var fileType = fileName[fileName.length-1].toLowerCase();
-        
+
         if (o.fileType.length > 0 && !$h.contains(o.fileType, fileType)) {
           o.fileTypeErrorCallback(file, errorCount++);
           return false;
@@ -492,7 +492,7 @@
           }
         });
         return(uploading);
-      };    
+      };
       $.isComplete = function(){
         var outstanding = false;
         $h.each($.chunks, function(chunk){
@@ -570,7 +570,7 @@
 
         // Add data from the query options
         var params = [];
-        var customQuery = $.getOpt('query'); 
+        var customQuery = $.getOpt('query');
         if(typeof customQuery == 'function') customQuery = customQuery($.fileObj, $);
         $h.each(customQuery, function(k,v){
           params.push([encodeURIComponent(k), encodeURIComponent(v)].join('='));
@@ -641,7 +641,7 @@
             $.callback('retry', $.message());
             $.abort();
             $.retries++;
-            var retryInterval = $.getOpt('chunkRetryInterval');          
+            var retryInterval = $.getOpt('chunkRetryInterval');
             if(retryInterval !== undefined) {
               $.pendingRetry = true;
               setTimeout($.send, retryInterval);
@@ -674,10 +674,10 @@
         });
 
         var func   = ($.fileObj.file.slice ? 'slice' : ($.fileObj.file.mozSlice ? 'mozSlice' : ($.fileObj.file.webkitSlice ? 'webkitSlice' : 'slice'))),
-        bytes  = $.fileObj.file[func]($.startByte,$.endByte), 
+        bytes  = $.fileObj.file[func]($.startByte,$.endByte),
         data   = null,
         target = $.getOpt('target');
-        
+
         if ($.getOpt('method') === 'octet') {
           // Add data from the query options
           data = bytes;
@@ -694,7 +694,7 @@
           });
           data.append($.getOpt('fileParameterName'), bytes);
         }
-        
+
         $.xhr.open('POST', target);
         $.xhr.timeout = $.getOpt('xhrTimeout');
         $.xhr.withCredentials = $.getOpt('withCredentials');
@@ -725,7 +725,7 @@
             // HTTP 200, perfect
             return('success');
           } else if($h.contains($.getOpt('permanentErrors'), $.xhr.status) || $.retries >= $.getOpt('maxChunkRetries')) {
-            // HTTP 415/500/501, permanent error
+            // HTTP 401/415/500/501, permanent error
             return('error');
           } else {
             // this should never happen, but we'll reset and queue a retry


### PR DESCRIPTION
In this case `resumable.js` should understand that the credentials it
provided were **invalid** for some reason and may want
to stop resending the chunks.

-offloads the server-side significantly on 401
