### PR TITLE
Added support for multiple part file extensions

### DIFF
--- a/resumable.js
+++ b/resumable.js
@@ -340,13 +340,21 @@
       }
       var files = [];
       $h.each(fileList, function(file){
-        var fileName = file.name.split('.');
-        var fileType = fileName[fileName.length-1].toLowerCase();
-        
-        if (o.fileType.length > 0 && !$h.contains(o.fileType, fileType)) {
-          o.fileTypeErrorCallback(file, errorCount++);
-          return false;
-        }
+        var fileName = file.name;
+        if(typeof(o.fileType)==='array' && o.fileType.length > 0){
+			var fileTypeFound = false;
+			for(var index in  ){
+				var extension = '.' + o.fileType[index];
+				if(fileName.indexOf(extension, fileName.length - extension.length) !== -1){
+					fileTypeFound = true;
+					break;
+				}
+			}
+			if (!fileTypeFound) {
+			  o.fileTypeErrorCallback(file, errorCount++);
+			  return false;
+			}
+		}
 
         if (typeof(o.minFileSize)!=='undefined' && file.size<o.minFileSize) {
           o.minFileSizeErrorCallback(file, errorCount++);

--- a/resumable.js
+++ b/resumable.js
@@ -343,7 +343,7 @@
         var fileName = file.name;
         if(typeof(o.fileType)==='array' && o.fileType.length > 0){
 			var fileTypeFound = false;
-			for(var index in  ){
+			for(var index in o.fileType){
 				var extension = '.' + o.fileType[index];
 				if(fileName.indexOf(extension, fileName.length - extension.length) !== -1){
 					fileTypeFound = true;

--- a/resumable.js
+++ b/resumable.js
@@ -341,7 +341,7 @@
       var files = [];
       $h.each(fileList, function(file){
         var fileName = file.name;
-        if(typeof(o.fileType)==='array' && o.fileType.length > 0){
+        if(o.fileType.length > 0){
 			var fileTypeFound = false;
 			for(var index in o.fileType){
 				var extension = '.' + o.fileType[index];


### PR DESCRIPTION
This adds support for multi part file extensions, ie .tar.gz to the file type validation.

To keep things compatible I needed to add the period before each extension.  Ideally the extensions would include the period, but to keep things compatible I kept this. The array could be updated with the period so this string manipulation wasn't required every time.