### PR TITLE
fix order of operations bug with duplicate files in one drag/drop

### DIFF
--- a/resumable.js
+++ b/resumable.js
@@ -369,10 +369,10 @@
           if (!$.getFromUniqueIdentifier(uniqueIdentifier)) {(function(){
             file.uniqueIdentifier = uniqueIdentifier;
             var f = new ResumableFile($, file, uniqueIdentifier);
+            $.files.push(f);
+            files.push(f);
+            f.container = (typeof event != 'undefined' ? event.srcElement : null);
             window.setTimeout(function(){
-              $.files.push(f);
-              files.push(f);
-              f.container = (typeof event != 'undefined' ? event.srcElement : null);
               $.fire('fileAdded', f, event)
             },0);
           })()};


### PR DESCRIPTION
You could add multiple files to the files array that had the same unique identifier if there were 2 files of the same name and size inside a single folder and it's subfolders if you dragged the parent folder into your resumable drop zone. 

This was because files were being added to the files array inside the setTimeout that wraps the fileAdded event trigger.  That meant files would be hitting the `if (!$.getFromUniqueIdentifier(uniqueIdentifier))` check before previous files were actually added to the array.