### PR TITLE
Allow overwrite of upload & test method

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,8 @@ Available configuration options are:
 * `simultaneousUploads` Number of simultaneous uploads (Default: `3`)
 * `fileParameterName` The name of the multipart POST parameter to use for the file chunk  (Default: `file`)
 * `query` Extra parameters to include in the multipart POST with data. This can be an object or a function. If a function, it will be passed a ResumableFile and a ResumableChunk object (Default: `{}`)
+* `testMethod` Method for chunk test request. (Default: `'GET'`)
+* `uploadMethod` Method for chunk upload request. (Default: `'POST'`)
 * `parameterNamespace` Extra prefix added before the name of each parameter included in the multipart POST or in the test GET. (Default: `''`)
 * `headers` Extra headers to include in the multipart POST with data (Default: `{}`)
 * `method` Method to use when POSTing chunks to the server (`multipart` or `octet`) (Default: `multipart`)

--- a/resumable.js
+++ b/resumable.js
@@ -44,6 +44,8 @@
       headers:{},
       preprocess:null,
       method:'multipart',
+      uploadMethod: 'POST',
+      testMethod: 'GET',
       prioritizeFirstAndLastChunk:false,
       target:'/',
       parameterNamespace:'',
@@ -627,7 +629,7 @@
         params.push([parameterNamespace+'resumableRelativePath', encodeURIComponent($.fileObj.relativePath)].join('='));
         params.push([parameterNamespace+'resumableTotalChunks', encodeURIComponent($.fileObj.chunks.length)].join('='));
         // Append the relevant chunk and send it
-        $.xhr.open('GET', $h.getTarget(params));
+        $.xhr.open($.getOpt('testMethod'), $h.getTarget(params));
         $.xhr.timeout = $.getOpt('xhrTimeout');
         $.xhr.withCredentials = $.getOpt('withCredentials');
         // Add data from header options
@@ -737,7 +739,11 @@
           data.append(parameterNamespace+$.getOpt('fileParameterName'), bytes);
         }
 
-        $.xhr.open('POST', target);
+        var method = $.getOpt('uploadMethod');
+        $.xhr.open(method, target);
+        if ($.getOpt('method') === 'octet') {
+          $.xhr.setRequestHeader('Content-Type', 'binary/octet-stream');
+        }
         $.xhr.timeout = $.getOpt('xhrTimeout');
         $.xhr.withCredentials = $.getOpt('withCredentials');
         // Add data from header options


### PR DESCRIPTION
Some endpoints prefer resources to be created via 'PUT' instead of a 'POST'. Also, doing a 'HEAD' to check if a resource already exists is quite a common thing out there. This PR adds the functionality to overwrite the methods via supplied options, so we don't need to change the default behaviour of resumable.