### PR TITLE
Revert response codes 202-2XX back to being negative responses

### DIFF
--- a/resumable.js
+++ b/resumable.js
@@ -773,8 +773,8 @@
           // Status is really 'OPENED', 'HEADERS_RECEIVED' or 'LOADING' - meaning that stuff is happening
           return('uploading');
         } else {
-          if($.xhr.status >= 200 && $.xhr.status < 300) {
-            // HTTP 2XX, perfect
+          if($.xhr.status == 200 || $.xhr.status == 201) {
+            // HTTP 200 or 201 (created) perfect
             return('success');
           } else if($h.contains($.getOpt('permanentErrors'), $.xhr.status) || $.retries >= $.getOpt('maxChunkRetries')) {
             // HTTP 415/500/501, permanent error


### PR DESCRIPTION
So the 204 (no content) code will continue to work as a non-failure logged negative response to resumable.js "test GET" requests.

This PR partially reverts the unintended and undesirable side-effects of another recently merged PR, per my comments here: https://github.com/23/resumable.js/pull/231#issuecomment-121111135

Thanks!  -Vaughn