### PR TITLE
Call readDir when dropping folders into Chrome

### DIFF
--- a/resumable.js
+++ b/resumable.js
@@ -310,6 +310,7 @@
                     }
                 );
             };
+          readDir(entry.fullPath);
         }
       }
     };


### PR DESCRIPTION
When dropping folders into Chrome, the function readDir is defined in
order to be able to recursively call the function. readDir is then
never actually called, the upshot of which being no folders ever get
added from a drop into Chrome.