### PR TITLE
Update PHP Sample to fix recreating file before file is finished uploading

### DIFF
--- a/samples/Backend on PHP.md
+++ b/samples/Backend on PHP.md
@@ -81,16 +81,19 @@ function rrmdir($dir) {
 function createFileFromChunks($temp_dir, $fileName, $chunkSize, $totalSize) {
 
     // count all the parts of this file
-    $total_files = 0;
+    $total_files_on_server_size = 0;
+    $temp_total = 0;
     foreach(scandir($temp_dir) as $file) {
+        $temp_total = $total_files_on_server_size;
+        $tempfilesize = filesize($temp_dir.'/'.$file);
+        $total_files_on_server_size = $temp_total + $tempfilesize;
         if (stripos($file, $fileName) !== false) {
             $total_files++;
         }
     }
-
     // check that all the parts are present
-    // the size of the last part is between chunkSize and 2*$chunkSize
-    if ($total_files * $chunkSize >=  ($totalSize - $chunkSize + 1)) {
+    // If the Size of all the chunks on the server is equal to the size of the file uploaded.
+        if ($total_files_on_server_size >= $totalSize) {
 
         // create the final destination file 
         if (($fp = fopen('temp/'.$fileName, 'w')) !== false) {

--- a/samples/Backend on PHP.md
+++ b/samples/Backend on PHP.md
@@ -87,15 +87,11 @@ function createFileFromChunks($temp_dir, $fileName, $chunkSize, $totalSize) {
         $temp_total = $total_files_on_server_size;
         $tempfilesize = filesize($temp_dir.'/'.$file);
         $total_files_on_server_size = $temp_total + $tempfilesize;
-        if (stripos($file, $fileName) !== false) {
-            $total_files++;
-        }
     }
     // check that all the parts are present
     // If the Size of all the chunks on the server is equal to the size of the file uploaded.
-        if ($total_files_on_server_size >= $totalSize) {
-
-        // create the final destination file 
+    if ($total_files_on_server_size >= $totalSize) {
+    // create the final destination file 
         if (($fp = fopen('temp/'.$fileName, 'w')) !== false) {
             for ($i=1; $i<=$total_files; $i++) {
                 fwrite($fp, file_get_contents($temp_dir.'/'.$fileName.'.part'.$i));


### PR DESCRIPTION
A problem was discovered in the PHP sample where the server would start
building the file before all the file’s chunks where received and
therefore corrupted the file. I have edited the code to do a check to
see if the server has the files equal to the size of the file being
uploaded before building the file.