### PR TITLE
Exposed API for manually handling change and drop events

### DIFF
--- a/resumable.js
+++ b/resumable.js
@@ -994,6 +994,13 @@
       });
       return(totalSize);
     };
+    $.handleDropEvent = function (e) {
+      onDrop(e);
+    };
+    $.handleChangeEvent = function (e) {
+      appendFilesFromFileList(e.target.files, e);
+      e.target.value = '';
+    };
 
     return(this);
   };


### PR DESCRIPTION
Currently resumable.js needs direct access to the DOM to bind event handlers - this is a problem for Angular2 applications in general, and specifically means that resumable can never be run in a web worker. By exposing an api to handle change and drop events the upload functionality of resumable can be used without a dependency on the DOM.