### PR TITLE
Fix typo in latest master that breaks resumableTotalChunks

### DIFF
--- a/resumable.js
+++ b/resumable.js
@@ -726,7 +726,7 @@
         query[$.getOpt('identifierParameterName')] = $.fileObj.uniqueIdentifier;
         query[$.getOpt('filenameParameterName')] = $.fileObj.fileName;
         query[$.getOpt('relativePathParameterName')] = $.fileObj.relativePath;
-        query[$.getOpt('totalChunksParameterName')] = $.fileObj.chunks.lengt;
+        query[$.getOpt('totalChunksParameterName')] = $.fileObj.chunks.length;
         // Mix in custom data
         var customQuery = $.getOpt('query');
         if(typeof customQuery == 'function') customQuery = customQuery($.fileObj, $);


### PR DESCRIPTION
Fixes typo in latest `master` that blatantly breaks package.
How did this even get accepted to merge into master?  
`resumableTotalChunks` ends up as "undefined" in all POST requests!!

