### PR TITLE
jQuery: check and switch '$' -> 'jQuery'

### DIFF
--- a/resumable.js
+++ b/resumable.js
@@ -5,8 +5,12 @@
 * Steffen Tiedemann Christensen, steffen@23company.com
 */
 
-(function(){
+(function($){
 "use strict";
+
+  if(!$){
+    throw new Error("jQuery is not defined but required by resumable.js");
+  }
 
   var Resumable = function(opts){
     if ( !(this instanceof Resumable) ) {
@@ -969,4 +973,4 @@
     window.Resumable = Resumable;
   }
 
-})();
+})(window.jQuery);


### PR DESCRIPTION
- existence of jQuery is checked before it is used
    - if not found a descriptive Error is thrown
- 'jQuery' global is used instead of '$' shorthand form
    - allows to use resumable.js in environments where '$'
      global is reserved (e.g. Microsoft SharePoint)