### PR TITLE
fixed skipping files

### DIFF
--- a/resumable.js
+++ b/resumable.js
@@ -358,7 +358,7 @@
               $.fire('fileAdded', f, event)
             },0);
           })()} else {
-            filesSkipped.push(f);
+            filesSkipped.push(file);
           };
           decreaseReamining();
         }


### PR DESCRIPTION
files which have already been uploaded (i.e. a file with the same
id already exists) should be skipped. because the non-existing
variable 'f' (define [here](https://github.com/23/resumable.js/blob/e932d21/resumable.js#L353)) was used, trying to upload the same file again resulted
in a 'variable f is not defined' error.

this commit fixes the error by using the proper 'file' variable