### PR TITLE
Re-add Firefox > 46 support.

### DIFF
--- a/resumable.js
+++ b/resumable.js
@@ -239,6 +239,8 @@
       }else if(item.isDirectory){
         // item is already a directory entry, just assign
         entry = item;
+      }else if(item instanceof File) {
+        items.push(item);
       }
       if('function' === typeof item.webkitGetAsEntry){
         // get entry from file object


### PR DESCRIPTION
I was tracking down a separate issue with Dragged files not clearing properly on cancel(), which looks like was addressed with the commits from the last few days.  (Thanks!)  Unfortunately, Firefox compatibility for dragging (versions 46 and up) isn't yet in -master.  This pull request adds it.

Thanks to ticket #318 and @falkmueller for the initial hint of what was going on.
