### PR TITLE
Use sensible filename for chunk upload

### DIFF
--- a/resumable.js
+++ b/resumable.js
@@ -769,7 +769,7 @@
             data.append(parameterNamespace + k, v);
             params.push([encodeURIComponent(parameterNamespace + k), encodeURIComponent(v)].join('='));
           });
-          data.append(parameterNamespace + $.getOpt('fileParameterName'), bytes);
+          data.append(parameterNamespace + $.getOpt('fileParameterName'), new File([bytes], $.fileObj.fileName));
         }
 
         var target = $h.getTarget('upload', params);


### PR DESCRIPTION
Using File with name = resumableFilename instead of Blob for upload of a chunk as multipart form data - this ensures that the filename property is not just "blob".