### PR TITLE
Pass file name as third parameter to FormData append

### DIFF
--- a/resumable.js
+++ b/resumable.js
@@ -769,7 +769,7 @@
             data.append(parameterNamespace + k, v);
             params.push([encodeURIComponent(parameterNamespace + k), encodeURIComponent(v)].join('='));
           });
-          data.append(parameterNamespace + $.getOpt('fileParameterName'), new File([bytes], $.fileObj.fileName));
+          data.append(parameterNamespace + $.getOpt('fileParameterName'), bytes, $.fileObj.fileName);
         }
 
         var target = $h.getTarget('upload', params);


### PR DESCRIPTION
Internet Explorer and Microsoft Edge don't support the File
constructor (see http://caniuse.com/#feat=fileapi).
However, the append method of FormData has a three parameter version:
formData.append(name, value, filename);

where "filename is the filename reported to the server (a USVString),
when a Blob or File is passed as the second parameter. The default
filename for Blob objects is "blob". The default filename for File
objects is the file's filename."
(see https://developer.mozilla.org/en-US/docs/Web/API/FormData/append)

The third parameter of FormData is not documented on Microsoft's Web
Platform API Reference:
https://msdn.microsoft.com/en-us/library/hh772724(v=vs.85).aspx

but I tested it on Internet Explorer 11 and it works as expected.