### PR TITLE
Add xhrTimeout option to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,7 @@ adding the file. (Default: `null`)
 * `maxChunkRetries` The maximum number of retries for a chunk before the upload is failed. Valid values are any positive integer and `undefined` for no limit. (Default: `undefined`)
 * `chunkRetryInterval` The number of milliseconds to wait before retrying a chunk on a non-permanent error.  Valid values are any positive integer and `undefined` for immediate retry.  (Default: `undefined`)
 * `withCredentials` Standard CORS requests do not send or set any cookies by default. In order to include cookies as part of the request, you need to set the `withCredentials` property to true. (Default: `false`)
+* `xhrTimeout` The timeout in milliseconds for each request (Default: `0`)
 
 #### Properties
 


### PR DESCRIPTION
I was looking for a timeout option in the documentation, but I couldn't find it. I found that it's already implemented so I thought it would be nice to have it in the readme file.