### PR TITLE
Added two alternative options: maxTotalAttachmentSize and maxTotalAttachmentSizeErrorCallback

### DIFF
--- a/resumable.js
+++ b/resumable.js
@@ -85,7 +85,11 @@
       fileType: [],
       fileTypeErrorCallback: function(file, errorCount) {
         alert(file.fileName||file.name +' has type not allowed, please upload files of type ' + $.getOpt('fileType') + '.');
-      }
+      },
+	  maxTotalAttachmentSize: undefined,
+	  maxTotalAttachmentSizeErrorCallback:function(file, errorCount) {
+		alert('Total uploaded files is too large, please upload less than ' + $h.formatSize($.getOpt('maxTotalAttachmentSize')) + ' size of files in total.');
+	  }
     };
     $.opts = opts||{};
     $.getOpt = function(o) {

--- a/resumable.js
+++ b/resumable.js
@@ -333,7 +333,7 @@
     var appendFilesFromFileList = function(fileList, event){
       // check for uploading too many files
       var errorCount = 0;
-      var o = $.getOpt(['maxFiles', 'minFileSize', 'maxFileSize', 'maxFilesErrorCallback', 'minFileSizeErrorCallback', 'maxFileSizeErrorCallback', 'fileType', 'fileTypeErrorCallback']);
+      var o = $.getOpt(['maxFiles', 'minFileSize', 'maxFileSize', 'maxFilesErrorCallback', 'minFileSizeErrorCallback', 'maxFileSizeErrorCallback', 'fileType', 'fileTypeErrorCallback', 'maxTotalAttachmentSize', 'maxTotalAttachmentSizeErrorCallback']);
       if (typeof(o.maxFiles)!=='undefined' && o.maxFiles<(fileList.length+$.files.length)) {
         // if single-file upload, file is already added, and trying to add 1 new file, simply replace the already-added file
         if (o.maxFiles===1 && $.files.length===1 && fileList.length===1) {
@@ -343,6 +343,21 @@
           return false;
         }
       }
+	  
+	var totalSize = 0;
+	$.files.forEach(function (resumeableFile) {
+		totalSize += resumeableFile.file.size;
+	});
+	jQuery.each(fileList, function(k, v) {
+		if (k != 'length') {
+			totalSize += v.size;
+			}
+	});
+	if (typeof (o.maxTotalAttachmentSize) != 'undefined' && totalSize > o.maxTotalAttachmentSize) {
+        o.maxTotalAttachmentSizeErrorCallback(fileList, errorCount++);
+        return false;
+    }
+
       var files = [], filesSkipped = [], remaining = fileList.length;
       var decreaseReamining = function(){
         if(!--remaining){


### PR DESCRIPTION
In some cases there are different requirements for max individual file size and max total size. The default value for maxTotalAttachmentSize is 'undefined' and if this value is not defined, resumable.js will simple ignore both this setting and the callback function.