### PR TITLE
Fix for thrown error when item.getAsFile() returns null 

### DIFF
--- a/resumable.js
+++ b/resumable.js
@@ -255,8 +255,10 @@
       if('function' === typeof item.getAsFile){
         // item represents a File object, convert it
         item = item.getAsFile();
-        item.relativePath = path + item.name;
-        items.push(item);
+        if(null !== item){
+          item.relativePath = path + item.name;
+          items.push(item);
+        }
       }
       cb(); // indicate processing is done
     }


### PR DESCRIPTION
In the processItem() method there's an assumption that a DataTransferItem will always return a file, but as per [the spec](https://developer.mozilla.org/en-US/docs/Web/API/DataTransferItem/getAsFile) it might return null.

This happens, for example, if someone with Chrome drags and drops some selected text onto the element Resumable is watching.

This PR adds a null check to avoid that error. 

Thanks for the library!