### PR TITLE
Better commonJs module integration

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "1.0.3",
   "description": "A JavaScript library for providing multiple simultaneous, stable, fault-tolerant and resumable/restartable uploads via the HTML5 File API.",
   "main": "resumable.js",
+  "types": "./resumable.d.ts",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
   },

--- a/resumable.d.ts
+++ b/resumable.d.ts
@@ -146,10 +146,10 @@ declare module Resumable  {
      **/
     withCredentials?: boolean;
   }
-  
+
   export class Resumable {
     constructor(options:ConfigurationHash);
-    
+
     /**
      * A boolean value indicator whether or not Resumable.js is supported by the current browser.
      **/
@@ -162,10 +162,10 @@ declare module Resumable  {
      * An array of ResumableFile file objects added by the user (see full docs for this object type below).
      **/
     files: Array<ResumableFile>;
-    
+
     events: Array<any>;
     version: number;
-    
+
     /**
      * Assign a browse action to one or more DOM nodes. Pass in true to allow directories to be selected (Chrome only).
      **/
@@ -217,7 +217,7 @@ declare module Resumable  {
      **/
     getSize(): void;
     getOpt(o: string): any;
-    
+
     // Events
     /**
      * Listen for event from Resumable.js (see below)
@@ -353,10 +353,10 @@ declare module Resumable  {
      **/
     isComplete: () => boolean;
   }
-  
+
   class ResumableChunk {}
 }
 
 declare module 'resumablejs' {
-  export = Resumable.Resumable;
+  export = Resumable;
 }

--- a/resumable.js
+++ b/resumable.js
@@ -1057,7 +1057,9 @@
 
   // Node.js-style export for Node and Component
   if (typeof module != 'undefined') {
+    // left here for backwards compatibility
     module.exports = Resumable;
+    module.exports.Resumable = Resumable;
   } else if (typeof define === "function" && define.amd) {
     // AMD/requirejs: Define the module
     define(function(){


### PR DESCRIPTION
This small fix allows better integration with commonJS module system and reflects it in TS definition.
Initially I've started to hacking it because of issue similar to #383. Workaround that proposed there breaks typings system. Unfortunately there is no small fix for types when project is compiled using webpack (and angular CLI) that provides good programming experience.

This fix also will provide better usage for ES6+ users, because it allows next syntax:
```TypeScript
import { Resumable } from 'resumablejs';
```
Which is valid in both ES6+ and TS.

### NOTES:
1. We could probably also add `default` import for using it as `import Resumable from 'resumablejs';`
2. It also will be great if you won't exclude `d.ts` files when publish this package to `npm`, so TS users won't have to explicitly add additional dependency for typings. In this case typings would be always up-to-date.