### PR TITLE
Add option for chunk Content-Type

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ adding the file. (Default: `null`)
 * `chunkRetryInterval` The number of milliseconds to wait before retrying a chunk on a non-permanent error.  Valid values are any positive integer and `undefined` for immediate retry.  (Default: `undefined`)
 * `withCredentials` Standard CORS requests do not send or set any cookies by default. In order to include cookies as part of the request, you need to set the `withCredentials` property to true. (Default: `false`)
 * `xhrTimeout` The timeout in milliseconds for each request (Default: `0`)
-
+* `setChunkTypeFromFile` Set chunk content-type from original file.type. (Default: `false`, if `false` default Content-Type: `application/octet-stream`)
 #### Properties
 
 * `.support` A boolean value indicator whether or not Resumable.js is supported by the current browser.

--- a/resumable.d.ts
+++ b/resumable.d.ts
@@ -145,6 +145,10 @@ declare module Resumable  {
      * Standard CORS requests do not send or set any cookies by default. In order to include cookies as part of the request, you need to set the withCredentials property to true. (Default: false)
      **/
     withCredentials?: boolean;
+    /**
+     * setChunkTypeFromFile` Set chunk content-type from original file.type. (Default: false, if false default Content-Type: application/octet-stream)
+     **/
+    setChunkTypeFromFile?: boolean;
   }
   
   export class Resumable {

--- a/resumable.js
+++ b/resumable.js
@@ -69,7 +69,7 @@
       withCredentials:false,
       xhrTimeout:0,
       clearInput:true,
-	    chunkFormat:'blob',
+      chunkFormat:'blob',
       setChunkTypeFromFile:false,
       maxFilesErrorCallback:function (files, errorCount) {
         var maxFiles = $.getOpt('maxFiles');

--- a/resumable.js
+++ b/resumable.js
@@ -69,7 +69,8 @@
       withCredentials:false,
       xhrTimeout:0,
       clearInput:true,
-	  chunkFormat:'blob',
+	    chunkFormat:'blob',
+      setChunkTypeFromFile:false,
       maxFilesErrorCallback:function (files, errorCount) {
         var maxFiles = $.getOpt('maxFiles');
         alert('Please upload no more than ' + maxFiles + ' file' + (maxFiles === 1 ? '' : 's') + ' at a time.');
@@ -752,7 +753,7 @@
         });
 
         var func = ($.fileObj.file.slice ? 'slice' : ($.fileObj.file.mozSlice ? 'mozSlice' : ($.fileObj.file.webkitSlice ? 'webkitSlice' : 'slice')));
-        var bytes = $.fileObj.file[func]($.startByte, $.endByte);
+        var bytes = $.fileObj.file[func]($.startByte, $.endByte, $.getOpt('setChunkTypeFromFile') ? $.fileObj.file.type : void 0);
         var data = null;
         var params = [];
 


### PR DESCRIPTION
Now content-type in chunk blobs allways octet-stream, this option allow set type of chunk blob from original file.type.
It is very helpfull in my use case, maybe some one need it too.