### PR TITLE
Fix drag and drop non file error

### DIFF
--- a/resumable.js
+++ b/resumable.js
@@ -256,8 +256,10 @@
       if('function' === typeof item.getAsFile){
         // item represents a File object, convert it
         item = item.getAsFile();
-        item.relativePath = path + item.name;
-        items.push(item);
+        if(item instanceof File) {
+          item.relativePath = path + item.name;
+          items.push(item);
+        }
       }
       cb(); // indicate processing is done
     }


### PR DESCRIPTION
When drag and drop something to drop zone, like text, item.getAsFile() returning null
Added check that item is File when push into items.
![2017-09-21 16-49-25](https://user-images.githubusercontent.com/6367733/30699293-fd1b3c4a-9eec-11e7-83ee-1b8da9097816.png)
https://developer.mozilla.org/en-US/docs/Web/API/DataTransferItem/getAsFile