### PR TITLE
Expose addFiles method

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,7 @@ adding the file. (Default: `null`)
 * `.progress()` Returns a float between 0 and 1 indicating the current upload progress of all files.
 * `.isUploading()` Returns a boolean indicating whether or not the instance is currently uploading anything.
 * `.addFile(file)` Add a HTML5 File object to the list of files.
+* `.addFiles(files)` Add an Array of HTML5 File objects to the list of files.
 * `.removeFile(file)` Cancel upload of a specific `ResumableFile` object on the list from the list.
 * `.getFromUniqueIdentifier(uniqueIdentifier)` Look up a `ResumableFile` object by its unique identifier.
 * `.getSize()` Returns the total size of the upload in bytes.

--- a/resumable-tests.ts
+++ b/resumable-tests.ts
@@ -4,6 +4,7 @@ let resumable: Resumable = new Resumable({chunkSize: 123});
 let resumableNoOpts: Resumable = new Resumable();
 
 resumable.addFile(new File([], 'test.tmp'), {});
+resumable.addFiles([new File([], 'test.tmp')], {});
 resumable.assignBrowse(document, true);
 resumable.assignBrowse([document], true);
 resumable.assignDrop(document);

--- a/resumable.d.ts
+++ b/resumable.d.ts
@@ -209,6 +209,10 @@ declare module Resumable  {
      **/
     addFile(file: File): void;
     /**
+     * Add an Array of HTML5 File objects to the list of files.
+     **/
+    addFiles(files: Array<File>): void;
+    /**
      * Cancel upload of a specific ResumableFile object on the list from the list.
      **/
     removeFile(file: ResumableFile): void;

--- a/resumable.js
+++ b/resumable.js
@@ -1029,6 +1029,9 @@
     $.addFile = function(file, event){
       appendFilesFromFileList([file], event);
     };
+    $.addFiles = function(file, event){
+      appendFilesFromFileList(files, event);
+    };
     $.removeFile = function(file){
       for(var i = $.files.length - 1; i >= 0; i--) {
         if($.files[i] === file) {

--- a/resumable.js
+++ b/resumable.js
@@ -1029,7 +1029,7 @@
     $.addFile = function(file, event){
       appendFilesFromFileList([file], event);
     };
-    $.addFiles = function(file, event){
+    $.addFiles = function(files, event){
       appendFilesFromFileList(files, event);
     };
     $.removeFile = function(file){


### PR DESCRIPTION
I exposed a new public method **addFiles**. It works same as **addFile** but you can pass multiple files at once.

```javascript
const resumable = new Resumable();
const files = [new File([], 'test.tmp'), new File([], 'foo.bar')];

resumable.addFiles(files);
```

This is needed in the case that you want to receive consistent events for bulk file adding.

Let me know if I need to update any other file.

Thanks!