### PR TITLE
Fix bug IE set content-type: undefined.

### DIFF
--- a/resumable.js
+++ b/resumable.js
@@ -755,7 +755,7 @@
         });
 
         var func = ($.fileObj.file.slice ? 'slice' : ($.fileObj.file.mozSlice ? 'mozSlice' : ($.fileObj.file.webkitSlice ? 'webkitSlice' : 'slice')));
-        var bytes = $.fileObj.file[func]($.startByte, $.endByte, $.getOpt('setChunkTypeFromFile') ? $.fileObj.file.type : void 0);
+        var bytes = $.fileObj.file[func]($.startByte, $.endByte, $.getOpt('setChunkTypeFromFile') ? $.fileObj.file.type : "");
         var data = null;
         var params = [];
 


### PR DESCRIPTION
The param void 0 return undefined in the Chrome and firefox it ok. But in the IE the content will be undefined.