### PR TITLE
Fixed generateUniqueIdentifer method signature

### DIFF
--- a/resumable.d.ts
+++ b/resumable.d.ts
@@ -100,7 +100,7 @@ declare module Resumable  {
     /**
      * Override the function that generates unique identifiers for each file. (Default: null)
      **/
-    generateUniqueIdentifier?: () => string;
+    generateUniqueIdentifier?: (file: File, event: Event) => Promise<string> | string;
     /**
      * Indicates how many files can be uploaded in a single session. Valid values are any positive integer and undefined for no limit. (Default: undefined)
      **/


### PR DESCRIPTION
Fixing up the type definition signature for `generateUniqueIdentifer`. Would be awesome to get this into the `1.1.0` release! 😄 

* generateUniqueIdentifer return type was missing type Promise<string>
* generateUniqueIdentifer arguments were missing