### PR TITLE
Allow more granular fileType matching

### DIFF
--- a/resumable.js
+++ b/resumable.js
@@ -950,7 +950,13 @@
         }
         var fileTypes = $.getOpt('fileType');
         if (typeof (fileTypes) !== 'undefined' && fileTypes.length >= 1) {
-          input.setAttribute('accept', fileTypes.map(function (e) { return '.' + e }).join(','));
+          input.setAttribute('accept', fileTypes.map(function (e) {
+            e = e.replace(/\s/g, '').toLowerCase();
+            if(e.match(/^[^.][^/]+$/)){
+              e = '.' + e;
+            }
+            return e;
+          }).join(','));
         }
         else {
           input.removeAttribute('accept');


### PR DESCRIPTION
Accept both file extensions (with and without dot) and MIME type and general MIME types.
Allow both file extension `mp4` and file extension `.mp3` and MIME types `image/jpeg` or general MIME types `video/*`

Also make some initially sanitations of each array entry.

Test case:
`fileType: ['pdf', '.docx','   mp4', '.mp3', 'video   /    *', '  image/jpeg  ', '  .PNG  ', '.ZiP']`  

Outputs:
`<input type="file" accept=".pdf,.docx,.mp4,.mp3,video/*,image/jpeg,.png,.zip" style="display: none;">`