### PR TITLE
[ADD] 409 (conflict) statusCode as permanent error

### DIFF
--- a/samples/coffeescript/resumable.js
+++ b/samples/coffeescript/resumable.js
@@ -64,7 +64,7 @@
       getTarget:null,
       maxChunkRetries:100,
       chunkRetryInterval:undefined,
-      permanentErrors:[400, 404, 415, 500, 501],
+      permanentErrors:[400, 404, 409, 415, 500, 501],
       maxFiles:undefined,
       withCredentials:false,
       xhrTimeout:0,


### PR DESCRIPTION
Hi,

I noticed that it was not throwing any errors when getting a 409 onConflict status code, resulting in an endless "die and retry" loop not fixable by the client.
Just adding the code in the `permanentErrors` array does the trick and fires the `fileError` event.