### PR TITLE
Ensure the extension fileType check is case insensitive.

### DIFF
--- a/resumable.js
+++ b/resumable.js
@@ -372,7 +372,7 @@
             // Allowing for both [extension, .extension, mime/type, mime/*]
             var extension = ((o.fileType[index].match(/^[^.][^/]+$/)) ? '.' : '') + o.fileType[index];
 
-            if ((fileName.substr(-1 * extension.length) === extension) ||
+            if ((fileName.substr(-1 * extension.length).toLowerCase() === extension) ||
               //If MIME type, check for wildcard or if extension matches the files tiletype
               (extension.indexOf('/') !== -1 && (
                 (extension.indexOf('*') !== -1 && fileType.substr(0, extension.indexOf('*')) === extension.substr(0, extension.indexOf('*')))  ||


### PR DESCRIPTION
In the list of fileTypes the items are all set to lowercase (line 370).
If the file has the name foo.MOV, if we have the fileTypes 'mov', 'MOV' it will fail to match.

This change ensures when we get the possible extension segment from the file we lowercase it, inline with our fileType list.

Makes the pr https://github.com/23/resumable.js/pull/319 redundant.
Fixes the issue https://github.com/Artear/ReactResumableJS/issues/20 (the workaround at the bottom is also broken due to the forced lowercase of the fileType ).