### PR TITLE
State charset explicitly.

### DIFF
--- a/resumable.js
+++ b/resumable.js
@@ -375,7 +375,7 @@
             if ((fileName.substr(-1 * extension.length).toLowerCase() === extension) ||
               //If MIME type, check for wildcard or if extension matches the files tiletype
               (extension.indexOf('/') !== -1 && (
-                (extension.indexOf('*') !== -1 && fileType.substr(0, extension.indexOf('*')) === extension.substr(0, extension.indexOf('*')))  ||
+                (extension.indexOf('*') !== -1 && fileType.substr(0, extension.indexOf('*')) === extension.substr(0, extension.indexOf('*'))) ||
                 fileType === extension
               ))
             ){

--- a/test.html
+++ b/test.html
@@ -1,6 +1,6 @@
 <a href="#" id="browseButton">Select files</a>
-
-<script src="resumable.js"></script>
+<meta charset="utf-8">
+<script src="resumable.js" charset="utf-8"></script>
 <script>
 var r = new Resumable({
   target: 'test.html'
@@ -48,6 +48,3 @@ r.on('cancel', function(){
     console.debug('cancel');
   });
 </script>
-
-
-


### PR DESCRIPTION
Not sure why, but Firefox Quantum (v58.0.2) seems to garble the encoding for `resumable.js` and insists that the character `Â` appears within the javascript source, which prevents loading the module. Explicitly including UTF-8 as the charset appears to fix that issue.