### PR TITLE
ResumableFile.setStartChunk() to indicate already completed chunks

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,6 +195,7 @@ adding the file. (Default: `null`)
 * `.bootstrap()` Rebuild the state of a `ResumableFile` object, including reassigning chunks and XMLHttpRequest instances.
 * `.isUploading()` Returns a boolean indicating whether file chunks is uploading.
 * `.isComplete()` Returns a boolean indicating whether the file has completed uploading and received a server response.
+* `.setStartChunk()` starts upload from this chunk number while marking all previous chunks complete.
 
 ## Alternatives
 

--- a/README.md
+++ b/README.md
@@ -195,7 +195,7 @@ adding the file. (Default: `null`)
 * `.bootstrap()` Rebuild the state of a `ResumableFile` object, including reassigning chunks and XMLHttpRequest instances.
 * `.isUploading()` Returns a boolean indicating whether file chunks is uploading.
 * `.isComplete()` Returns a boolean indicating whether the file has completed uploading and received a server response.
-* `.setStartChunk()` starts upload from this chunk number while marking all previous chunks complete.
+* `.setStartChunk()` starts upload from this chunk number while marking all previous chunks complete. Must be called before upload() method.
 
 ## Alternatives
 

--- a/README.md
+++ b/README.md
@@ -195,7 +195,7 @@ adding the file. (Default: `null`)
 * `.bootstrap()` Rebuild the state of a `ResumableFile` object, including reassigning chunks and XMLHttpRequest instances.
 * `.isUploading()` Returns a boolean indicating whether file chunks is uploading.
 * `.isComplete()` Returns a boolean indicating whether the file has completed uploading and received a server response.
-* `.setStartChunk()` starts upload from this chunk number while marking all previous chunks complete. Must be called before upload() method.
+* `.markChunksCompleted()` starts upload from the next chunk number while marking all previous chunks complete. Must be called before upload() method.
 
 ## Alternatives
 

--- a/resumable.js
+++ b/resumable.js
@@ -613,14 +613,14 @@
         }
         return(found);
       }
-    $.setStartChunk = function (startChunkNumber) {
-      if (!$.chunks || $.chunks.length < startChunkNumber) {
-          return;
-      }
-      for (var num = 0; num < startChunkNumber-1; num++) {
-          $.chunks[num].markComplete = true;
-      }
-  };
+      $.markChunksCompleted = function (chunkNumber) {
+        if (!$.chunks || $.chunks.length <= chunkNumber) {
+            return;
+        }
+        for (var num = 0; num < chunkNumber; num++) {
+            $.chunks[num].markComplete = true;
+        }
+      };
 
       // Bootstrap and return
       $.resumableObj.fire('chunkingStart', $);

--- a/resumable.js
+++ b/resumable.js
@@ -613,6 +613,14 @@
         }
         return(found);
       }
+    $.setStartChunk = function (startChunkNumber) {
+      if (!$.chunks || $.chunks.length < startChunkNumber) {
+          return;
+      }
+      for (var num = 0; num < startChunkNumber-1; num++) {
+          $.chunks[num].markComplete = true;
+      }
+  };
 
       // Bootstrap and return
       $.resumableObj.fire('chunkingStart', $);
@@ -636,6 +644,7 @@
       $.retries = 0;
       $.pendingRetry = false;
       $.preprocessState = 0; // 0 = unprocessed, 1 = processing, 2 = finished
+      $.markComplete = false;
 
       // Computed properties
       var chunkSize = $.getOpt('chunkSize');
@@ -868,6 +877,8 @@
           // if pending retry then that's effectively the same as actively uploading,
           // there might just be a slight delay before the retry starts
           return('uploading');
+        } else if($.markComplete) {
+          return 'success';
         } else if(!$.xhr) {
           return('pending');
         } else if($.xhr.readyState<4) {

--- a/resumable.js
+++ b/resumable.js
@@ -906,7 +906,7 @@
         if(typeof(relative)==='undefined') relative = false;
         var factor = (relative ? ($.endByte-$.startByte)/$.fileObjSize : 1);
         if($.pendingRetry) return(0);
-        if(!$.xhr || !$.xhr.status) factor*=.95;
+        if((!$.xhr || !$.xhr.status) && !$.markComplete) factor*=.95;
         var s = $.status();
         switch(s){
         case 'success':


### PR DESCRIPTION
resumableFile.setStartChunk(n) marks all 1 to (n-1) chunks as complete. The testing/upload for chunks starts from nth chunk. The progress() method also starts from the relevant percent.

Usage:
Has to be before upload() method
resumable.on('fileAdded', function(file){
let startChunk = 5;
file.setStartChunk(startChunk);
resumable.upload();
}