### PR TITLE
Transmit the return message to the fileProgress event

### DIFF
--- a/resumable.js
+++ b/resumable.js
@@ -475,7 +475,7 @@
           break;
         case 'success':
           if(_error) return;
-          $.resumableObj.fire('fileProgress', $); // it's at least progress
+          $.resumableObj.fire('fileProgress', $, message); // it's at least progress
           if($.isComplete()) {
             $.resumableObj.fire('fileSuccess', $, message);
           }


### PR DESCRIPTION
Allow the fileProgress listener function to retrieve the return message.
Fix bug  #479