### PR TITLE
Continue adding files after the first one invalid

### DIFF
--- a/resumable.js
+++ b/resumable.js
@@ -392,17 +392,17 @@
           }
           if (!fileTypeFound) {
             o.fileTypeErrorCallback(file, errorCount++);
-            return false;
+            return true;
           }
         }
 
         if (typeof(o.minFileSize)!=='undefined' && file.size<o.minFileSize) {
           o.minFileSizeErrorCallback(file, errorCount++);
-          return false;
+          return true;
         }
         if (typeof(o.maxFileSize)!=='undefined' && file.size>o.maxFileSize) {
           o.maxFileSizeErrorCallback(file, errorCount++);
-          return false;
+          return true;
         }
 
         function addFile(uniqueIdentifier){


### PR DESCRIPTION
When selecting multiple files or a full directory, the insertion stop at the first error, so reaming files are never added.

Related to issue #486