### PR TITLE
Retry aborted chunks on OS sleep

### DIFF
--- a/resumable.js
+++ b/resumable.js
@@ -781,6 +781,7 @@
         };
         $.xhr.addEventListener('load', doneHandler, false);
         $.xhr.addEventListener('error', doneHandler, false);
+        $.xhr.addEventListener('abort', doneHandler, false);
         $.xhr.addEventListener('timeout', doneHandler, false);
 
         // Set up the basic query data from Resumable


### PR DESCRIPTION
When OSX goes to sleep, Chrome throws `abort` on any running XHRs. On wake, this unhandled event causes resumable to hang. With this change, an upload will resume on wake.