### PR TITLE
Generated identifier when dropping a folder on Chome and Edge does no…

### DIFF
--- a/resumable.js
+++ b/resumable.js
@@ -162,7 +162,7 @@
         if(typeof custom === 'function') {
           return custom(file, event);
         }
-        var relativePath = file.webkitRelativePath||file.fileName||file.name; // Some confusion in different versions of Firefox
+        var relativePath = file.webkitRelativePath||file.relativePath||file.fileName||file.name; // Some confusion in different versions of Firefox
         var size = file.size;
         return(size + '-' + relativePath.replace(/[^0-9a-zA-Z_-]/img, ''));
       },


### PR DESCRIPTION
…t contains the relativePath

The generated identifier function when dropping a folder on Chome and Edge does not contains the relativePath:
Fix bug #489