### PR TITLE
Fixes problem that target url ends with & when all the params disabled

### DIFF
--- a/resumable.js
+++ b/resumable.js
@@ -212,7 +212,9 @@
         var separator = target.indexOf('?') < 0 ? '?' : '&';
         var joinedParams = params.join('&');
 
-        return target + separator + joinedParams;
+        if (joinedParams) target = target + separator + joinedParams;
+
+        return target;
       }
     };
 


### PR DESCRIPTION
In our case, we use special headers for metadata, so I had to disable all url params and found that still '&' is added.