### PR TITLE
Add 401 and 403 to permanent errors

### DIFF
--- a/resumable.js
+++ b/resumable.js
@@ -66,7 +66,7 @@
       getTarget:null,
       maxChunkRetries:100,
       chunkRetryInterval:undefined,
-      permanentErrors:[400, 404, 409, 415, 500, 501],
+      permanentErrors:[400, 401, 403, 404, 409, 415, 500, 501],
       maxFiles:undefined,
       withCredentials:false,
       xhrTimeout:0,


### PR DESCRIPTION
Add `401 Unauthorized` and `403 Forbidden` to `permanentErrors`.
It doesn't make any sense to to try to resend the chunk in those cases.

Fix #354
Close #205