### PR TITLE
Fix type definitions

### DIFF
--- a/resumable.d.ts
+++ b/resumable.d.ts
@@ -116,7 +116,7 @@ declare module Resumable  {
     /**
      * The minimum allowed file size. (Default: undefined)
      **/
-    minFileSize?: boolean;
+    minFileSize?: number;
     /**
      * A function which displays an error a selected file is smaller than allowed. (Default: displays an alert for every bad file.)
      **/
@@ -124,7 +124,7 @@ declare module Resumable  {
     /**
      * The maximum allowed file size. (Default: undefined)
      **/
-    maxFileSize?: boolean;
+    maxFileSize?: number;
     /**
      * A function which displays an error a selected file is larger than allowed. (Default: displays an alert for every bad file.)
      **/


### PR DESCRIPTION
Using Resumable.js while setting the `maxFileSize` (and `minFileSize` likewise) from Angular 6 breaks our build. The reason is that the file size are specified as boolean in the typescript type definitions file.

This PR just changes the declared types of these 2 fields of the `ConfigurationHash`