### PR TITLE
Update types to make ResumableFile.progress argument optional.

### DIFF
--- a/resumable.d.ts
+++ b/resumable.d.ts
@@ -337,9 +337,9 @@ declare namespace Resumable {
 
 
     /**
-     * Returns a float between 0 and 1 indicating the current upload progress of the file. If relative is true, the value is returned relative to all files in the Resumable.js instance.
+     * Returns a float between 0 and 1 indicating the current upload progress of the file.
      **/
-    progress: (relative: boolean) => number;
+    progress: () => number;
     /**
      * Abort uploading the file.
      **/
@@ -366,7 +366,12 @@ declare namespace Resumable {
     isComplete: () => boolean;
   }
 
-  interface ResumableChunk { }
+  interface ResumableChunk {
+    /**
+     * Returns a float between 0 and 1 indicating the current upload progress of the file. If relative is true, the value is returned relative to all files in the Resumable.js instance.
+     **/
+    progress: (relative?: boolean) => number;
+  }
 }
 
 declare module 'resumablejs' {


### PR DESCRIPTION
I might be misinterpreting the source code, but I think the ResumableFile.progress function doesn't seem to take any arguments, where the ResumableChunk.progress does take an optional argument.

I was initially going to just make the ResumableFile.progress argument optional, and while that will fix the issue I'm running in to, I found what I thought was a larger issue, thus my type changes.

In `ResumableFile`:
```
      $.progress = function(){
        if(_error) return(1);
        // Sum up progress across everything
        var ret = 0;
        var error = false;
        $h.each($.chunks, function(c){
          if(c.status()=='error') error = true;
          ret += c.progress(true); // get chunk progress relative to entire file
        });
        ret = (error ? 1 : (ret>0.99999 ? 1 : ret));
        ret = Math.max($._prevProgress, ret); // We don't want to lose percentages when an upload is paused
        $._prevProgress = ret;
        return(ret);
      };
```

And in `ResumableChunk`:
```
      $.progress = function(relative){
        if(typeof(relative)==='undefined') relative = false;
        var factor = (relative ? ($.endByte-$.startByte)/$.fileObjSize : 1);
        if($.pendingRetry) return(0);
        if((!$.xhr || !$.xhr.status) && !$.markComplete) factor*=.95;
        var s = $.status();
        switch(s){
        case 'success':
        case 'error':
          return(1*factor);
        case 'pending':
          return(0*factor);
        default:
          return($.loaded/($.endByte-$.startByte)*factor);
        }
      };
```