### PR TITLE
Add ResumableFileObject to target-callback

### DIFF
--- a/resumable.js
+++ b/resumable.js
@@ -198,7 +198,7 @@
           return (size/1024.0/1024.0/1024.0).toFixed(1) + ' GB';
         }
       },
-      getTarget:function(request, params){
+      getTarget:function(request, params, fileObj){
         var target = $.getOpt('target');
 
         if (request === 'test' && $.getOpt('testTarget')) {
@@ -206,7 +206,7 @@
         }
 
         if (typeof target === 'function') {
-          return target(params);
+          return target(params, fileObj);
         }
 
         var separator = target.indexOf('?') < 0 ? '?' : '&';
@@ -739,7 +739,7 @@
           })
         );
         // Append the relevant chunk and send it
-        $.xhr.open($.getOpt('testMethod'), $h.getTarget('test', params));
+        $.xhr.open($.getOpt('testMethod'), $h.getTarget('test', params, $.fileObj));
         $.xhr.timeout = $.getOpt('xhrTimeout');
         $.xhr.withCredentials = $.getOpt('withCredentials');
         // Add data from header options
@@ -871,7 +871,7 @@
                     }
                 }
 
-        var target = $h.getTarget('upload', params);
+        var target = $h.getTarget('upload', params, $.fileObj);
         var method = $.getOpt('uploadMethod');
 
         $.xhr.open(method, target);


### PR DESCRIPTION
I needed this functionality because I had to re-calculate the target-url for each file based on information I added to the ResumableFile-Object in the "fileAdded"-Hook.

Basically the information is only available when the user adds the file to the queue. This information is not available at the time of the actual uploading. 

Therefore I add this piece of information to the ResumableFileObject when the "fileAdded"-Hook fires. Later, when the target-callback is executed, I retrieve it from the ResumableFileObject.