### PR TITLE
Fix min and max file size type defs

### DIFF
--- a/resumable.d.ts
+++ b/resumable.d.ts
@@ -112,7 +112,7 @@ declare namespace Resumable {
     /**
      * The minimum allowed file size. (Default: undefined)
      **/
-    minFileSize?: boolean;
+    minFileSize?: number;
     /**
      * A function which displays an error a selected file is smaller than allowed. (Default: displays an alert for every bad file.)
      **/
@@ -120,7 +120,7 @@ declare namespace Resumable {
     /**
      * The maximum allowed file size. (Default: undefined)
      **/
-    maxFileSize?: boolean;
+    maxFileSize?: number;
     /**
      * A function which displays an error a selected file is larger than allowed. (Default: displays an alert for every bad file.)
      **/


### PR DESCRIPTION
Min file size and max file size are erroneously set to be `boolean` instead of `number` in the type def file