### PR TITLE
204 instead of 404 in PHP example code.

### DIFF
--- a/samples/Backend on PHP.md
+++ b/samples/Backend on PHP.md
@@ -139,7 +139,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'GET') {
     if (file_exists($chunk_file)) {
          header("HTTP/1.0 200 Ok");
        } else {
-         header("HTTP/1.0 404 Not Found");
+         header("HTTP/1.0 204 No Content");
        }
 }
 


### PR DESCRIPTION
Return HTTP 204 when chunk is not found, avoiding errors in browser console as per the README recommendation 
( https://github.com/23/resumable.js#handling-get-or-test-requests )