### PR TITLE
added vue example as git submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "samples/resumable-vue"]
+	path = samples/resumable-vue
+	url = git@github.com:AbrahamBrookes/resumable-vue.git


### PR DESCRIPTION
I built a barebones vue example that implements resumablejs [here](https://github.com/AbrahamBrookes/resumable-vue) 

Thought it might be nice to give other vue users an example of one way to implement the library into a vue environment.

I added it as a submodule instead of straight copy pasting the files, but if you'd prefer I just copy the couple of files that are required (`src/components/UploadVideos.vue` and `src/components/UploadingVideo.vue`) then let me know and I'll redo the fork.

Cheers!