### PR TITLE
updating regex to handle chinese characters

### DIFF
--- a/resumable.js
+++ b/resumable.js
@@ -172,7 +172,8 @@
         }
         var relativePath = file.webkitRelativePath||file.relativePath||file.fileName||file.name; // Some confusion in different versions of Firefox
         var size = file.size;
-        return(size + '-' + relativePath.replace(/[^0-9a-zA-Z_-]/img, ''));
+        //the below regex helps in handling chinese character filenames which gets ignored because of unicode
+        return(size + '-' + relativePath.replace(/[^0-9a-zA-Z_-\u3040-\u30ff\u3400-\u4dbf\u4e00-\u9fff\uf900-\ufaff\uff66-\uff9f]/img, ''));
       },
       contains:function(array,test) {
         var result = false;


### PR DESCRIPTION
At present, the current regex doesn't take care of when we are passing filenames having chinese characters. 

The bug reproduction steps:
Take three files with names as "平行级_高速轴_中间_001.xml", "平行级_高速轴_叶片侧_001.xml", "平行级_高速轴_电机侧_001.xml" and perform an upload. The uniqueIdentifier was not getting generated, like below:

![image](https://user-images.githubusercontent.com/18312520/229512765-63295aab-0149-4fc6-8c82-399b149303ef.png)


As a fix for this, we have started respecting chinese characters(unicode) in the regex.